### PR TITLE
Added functionality to change post order according to timestamps

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -78,3 +78,12 @@
 .darkmode--activated #nav-id {
   background-color: #d3d3d3 !important;
 }
+.orderForms {
+  display:flex; 
+  justify-content: space-between;
+}
+
+.orderSelect {
+  padding: 5px;
+  margin-right: 5px;
+}

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -13,22 +13,56 @@
     <button class="btn btn-primary" type="submit" name="search">Search</button>
 </form>
 <% if(search!="") {%>
-    <form action="/search/<%= search %>/<%= current %>/<%= perPage %>" method="GET" class="quantityForm">
-        <label for="quantity">Number of posts to display on this page:</label>
-        <input type="number" name="perPage" min="1" max="10" value=<%= perPage %>>
-        <input type="submit">
-    </form>
+    <div class="orderForms">
+        <form action="/search/<%= search %>/<%= current %>/<%= perPage %>" method="GET" class="quantityForm">
+            <label for="quantity">Number of posts to display on this page:</label>
+            <input type="number" name="perPage" min="1" max="10" value=<%= perPage %>>
+            <input type="submit">
+        </form>
+        <form action="/search/<%= search %>/<%= current %>/<%= perPage %>" method="GET" class="quantityForm">
+            <select name="order" class="orderSelect">
+                <% if(order==='new one first') {%> 
+                    <option value="new one first" selected>New one first</option>
+                <% }else {%>
+                    <option value="new one first">New one first</option> 
+                <% }if(order==='old one first') {%> 
+                    <option value="old one first" selected>Old one first</option>
+                <%} else {%>
+                    <option value="old one first">Old one first</option>
+                <% }  %>
+                <input type="submit"/>
+            </select>
+        </form>
+    </div>
 <% } else { %>
-    <form action="/page/<%= current %>/<%= perPage %>" method="GET" class="quantityForm">
-        <label for="quantity">Number of posts to display on this page:</label>
-        <input type="number" name="perPage" min="1" max="10" value=<%= perPage %>>
-        <input type="submit">
-    </form>
+    <div class="orderForms">
+        <form action="/page/<%= current %>/<%= perPage %>" method="GET" class="quantityForm">
+            <label for="quantity">Number of posts to display on this page:</label>
+            <input type="number" name="perPage" min="1" max="10" value=<%= perPage %>>
+            <input type="submit">
+        </form>
+        <form action="/page/<%= current %>/<%= perPage %>" method="GET" class="quantityForm">
+            <select name="order" class="orderSelect">
+                <% if(order==='new one first') {%> 
+                    <option value="new one first" selected>New one first</option>
+                <% }else {%>
+                    <option value="new one first">New one first</option> 
+                <% }if(order==='old one first') {%> 
+                    <option value="old one first" selected>Old one first</option>
+                <%} else {%>
+                    <option value="old one first">Old one first</option>
+                <% }  %>
+                <input type="submit"/>
+            </select>
+        </form>
+    </div> 
 <% } %>
     
 <% posts.forEach(function (post) { %>
     <div class="post">
         <h1> <%= post.blogTitle %> </h1>
+        <p>Posted on <%= new Date(post.timestamps) %> </p>
+        <hr/>
         <p> <%= post.blogContent.substring(0,100) + ("...") %> 
             <span><a href="posts/<%= post.blogTitle %>" >Read More</a></span>
         </p>


### PR DESCRIPTION
## Features added
 - Added the timestamps field in the post schema.
 - Added input field to select the post order for both the search and home routes (by default posts are arranged as recent one first).
 - Added corresponding styles for the input fields.

## Related issue?
Fixes #87 

## Checklist:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [x] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you tested the code before submission?

## Demo Video:

https://user-images.githubusercontent.com/35343652/105891649-e025b480-6036-11eb-96ff-7aebecec6ef5.mp4

