### PR TITLE
Added margin to nav bar

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -99,6 +99,9 @@ body {
 .normal-heading-font{
   font-family: 'Open Sans', sans-serif;
 }
+#first-heading{
+	margin-top:80px;
+}
 .heading-centre{
   text-align: center;
   padding: 1rem;

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,6 +1,6 @@
 <%- include("partials/header", {isAuthenticated}) -%>
 
-<h2 class="normal-heading-font" style="font-weight:600;">Hi there!</h2>
+<h2 id="first-heading" class="normal-heading-font" style="font-weight:600;">Hi there!</h2>
 <p class="content-body-font"> <%= homeStartingContent %> </p> 
 <h3 class="normal-heading-font" style="font-weight:600;">Anything New?</h3>
 


### PR DESCRIPTION
## What is the change?
Added a margin between nav bar and the first heading.

## Related issue?
issue: #232

## How was it tested?
First the environment was setup according to readme. Then, a css property first-heading was added which contains only "margin-top:80px;". Then this property was used in the first Heading.

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [x] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you tested the code before submission?

## Screenshots or Video:

![image](https://user-images.githubusercontent.com/68701271/110377794-d69e5c00-807a-11eb-8a83-5461857fa4af.png)
