### PR TITLE
Add an additional note in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,5 +27,8 @@ If applicable, add screenshots to help explain your problem.
 Add any other context about the problem here.
 
 
-Note: If you want to work on an issue, you should check if it has already been assigned to anyone. If the issue is free you can comment `/assign` to get the issue assigned to you.
-If you are raising a new issue and want to work on it then also you should comment `/assign` under the issue to get it auto assigned.
+
+**Note:**
+* If you want to work on an issue, you should check if it has already been assigned to anyone. **If the issue is free** you can comment `/assign` to get the issue assigned to you.
+* If you are raising a new issue and want to work on it then also you should comment `/assign` under the issue to get it auto assigned.
+* Please **refrain from** adding labels to your issue/pull-request on your own. It is the job of the Project Admin and the Mentors to review your issue/pull-request and add labels accordingly.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -24,7 +24,8 @@ Add any other context or screenshots about the feature request here.
 
 <hr/>
 
-Note:  
-If you want to work on an issue, you should check if it has already been assigned to anyone. If the issue is free you can comment `/assign` to get the issue assigned to you.  
-If you are raising a new issue and want to work on it then also you should comment `/assign` under the issue to get it auto assigned.  
-Then you can directly start working on the issue.  
+
+**Note:**
+* If you want to work on an issue, you should check if it has already been assigned to anyone. **If the issue is free** you can comment `/assign` to get the issue assigned to you.
+* If you are raising a new issue and want to work on it then also you should comment `/assign` under the issue to get it auto assigned.
+* Please **refrain from** adding labels to your issue/pull-request on your own. It is the job of the Project Admin and the Mentors to review your issue/pull-request and add labels accordingly.


### PR DESCRIPTION
## What is the change?
Updated the note in the issue templates to prevent participants from assigning labels on their issue/pull-request themselves.

## Checklist:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [x] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you tested the code before submission?