### PR TITLE
Comments added on the right of 'Read More' button on home page for posts.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -399,7 +399,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -782,8 +781,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -1784,8 +1782,7 @@
         "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
         "node": ">=4"

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -73,7 +73,11 @@
                 <div class="post-content-font">
                     <%- post.blogContent.substring(0,15000000) + ("...") %>
                 </div>
-                <a href="posts/<%= post._id %>"><button class="button read">Read More</button></a>
+                <div>
+                    <a href="posts/<%= post._id %>"><button class="button read">Read More</button></a>
+                <i class="fa fa-comment fa-2x" style="float: right;" aria-hidden="true"><%= post.comments.length %></i>
+                </div>
+                
             </div>
         <% }); %>
     </div>


### PR DESCRIPTION
## What is the change?
Added number of comments on the home page for posts.

## Related issue?
close: #415 


## How was it tested?
No errors generated.

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you tested the code before submission?

## Screenshots or Video:
![Screenshot from 2021-03-24 11-29-40](https://user-images.githubusercontent.com/63252119/112264945-a7e9cd80-8c97-11eb-96d5-8e4ef68ce9e8.png)
