### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1620,8 +1620,8 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.1.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "nodemailer": {
@@ -1772,7 +1772,7 @@
         "co": "^4.6.0",
         "degenerator": "^1.0.4",
         "ip": "^1.1.5",
-        "netmask": "^1.0.6",
+        "netmask": "^2.0.1",
         "thunkify": "^2.1.2"
       }
     },


### PR DESCRIPTION
Update netmask version to fix security vulnerability.
ref link- https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/
