### PR TITLE
add(option-select): compose post section

### DIFF
--- a/views/compose.ejs
+++ b/views/compose.ejs
@@ -32,6 +32,7 @@
               class="form-control col-md-12 col-sm-12 col-xs-12"
               required
             >
+            <option value="" disabled hidden selected>Select a category</option>
             <% categories.forEach(item => { %>
                 <option value="<%= item %>">
                   <%= item %> 


### PR DESCRIPTION
## What is the change?
Added default text/option for selecting a category while composing a blog

## Related issue?
close: #567 


## How was it tested?
web client 

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you tested the code before submission?

## Screenshots or Video:
![image](https://user-images.githubusercontent.com/59313375/113471966-99609a80-947d-11eb-9d6e-055c0ec4a7bd.png)
