### PR TITLE
Added show password feature on signup and edit profile page issue#668

### DIFF
--- a/public/js/showHidePassword.js
+++ b/public/js/showHidePassword.js
@@ -1,5 +1,5 @@
 let state = false;
-function togglePassword(target='password',icon='eye') {
+function togglePassword(target = 'password', icon = 'eye') {
     if (state) {
         document.getElementById(target).setAttribute('type', 'password');
         document.getElementById(icon).classList.remove('fa-eye-slash');

--- a/public/js/showHidePassword.js
+++ b/public/js/showHidePassword.js
@@ -1,11 +1,11 @@
 let state = false;
-function togglePassword() {
+function togglePassword(target='password',icon='eye') {
     if (state) {
-        document.getElementById('password').setAttribute('type', 'password');
-        document.getElementById('eye').classList.remove('fa-eye-slash');
+        document.getElementById(target).setAttribute('type', 'password');
+        document.getElementById(icon).classList.remove('fa-eye-slash');
     } else {
-        document.getElementById('password').setAttribute('type', 'text');
-        document.getElementById('eye').classList.add('fa-eye-slash');
+        document.getElementById(target).setAttribute('type', 'text');
+        document.getElementById(icon).classList.add('fa-eye-slash');
     }
     state = !state;
 }

--- a/views/auth/signUp.ejs
+++ b/views/auth/signUp.ejs
@@ -36,11 +36,13 @@
                         <label class="sign-up-place">Password</label>
                         <input class="form-control col-md-12 col-sm-12 col-xs-12" type="password" id="password" name="password"
                             autocomplete="off" value="<%= data.password %>" required></input>
+                        <span class="password-icon"><i class="fa fa-eye" id="eye" onclick="togglePassword()"></i></span>
                     </div>
                     <div class="form-group">
                         <label class="sign-up-place">Confirm Password</label>
                         <input class="form-control col-md-12 col-sm-12 col-xs-12" type="password" id="confirmPassword" name="confirmPassword"
                             autocomplete="off" value="<%= data.confirmPassword %>" required></input>
+                        <span class="password-icon"><i class="fa fa-eye" id="eye2" onclick="togglePassword('confirmPassword','eye2')"></i></span>
                     </div>
                     <div class="registrationFormAlert" style="color:red;" id="CheckPasswordMatch"></div>
                     <div class="text-center">
@@ -51,4 +53,5 @@
             </div>
     </div>
     <script type="text/javascript" src="/js/checkPasswordMatch.js" defer></script>
+    <script type="text/javascript" src="/js/showHidePassword.js"></script>
 <%- include("../partials/footer") -%>

--- a/views/useritems/read-profile.ejs
+++ b/views/useritems/read-profile.ejs
@@ -37,7 +37,8 @@
                     <div class="form-group">
                         <label class="col-md-3 control-label" for="password">Password:</label>
                         <div class="col-md-8">
-                            <input class="form-control" type="password" for="password" name="password">
+                            <input class="form-control" type="password" name="password" id="password">
+                            <span class="password-icon pb-3 pr-3"><i class="fa fa-eye" id="eye" onclick="togglePassword()"></i></span>
                         </div>
                     </div>
                     <div class="form-group">
@@ -53,4 +54,5 @@
         </div>
     </div>
     <hr>
+    <script type="text/javascript" src="/js/showHidePassword.js"></script>
 <%- include("../partials/footer") -%>


### PR DESCRIPTION
## What is the change?
Added show password feature on signup page and edit profile page just like login page

## Related issue?
close: #668 


## How was it tested?
Tested 

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [] Did you lint your code before making the Pull Request?
- [] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you tested the code before submission?

## Screenshots or Video:
Add a screenshot or demo video if appropriate.

https://user-images.githubusercontent.com/68139755/114314659-27d9b980-9b19-11eb-935e-c4c9c3c89ba7.mp4

